### PR TITLE
Remove instagram links

### DIFF
--- a/css/site.scss
+++ b/css/site.scss
@@ -245,7 +245,7 @@ p.centered {
   border-radius: $btn-border-radius-base;
 }
 
-.getinvolved {
+.linkrow {
   display: flex;
   flex-wrap: wrap;
   div {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ permalink: /
       </p>
     </div>
   </div>
-  <div class="row getinvolved">
+  <div class="row linkrow">
     <div class="col-sm-4 col-sm-offset-2 col-xs-12">
       <img class="centered" src="{{ site.baseurl }}/images/Icon-Volunteer.png" />
       <h2>Get Involved</h2>
@@ -51,31 +51,24 @@ permalink: /
   {% include imagerow.html src="Homepage-photo2.jpg" %}
   <div class="row padbottom50">
     <div class="col-sm-offset-1 col-sm-10 col-xs-12">
-      <div class="row">
+      <div class="row linkrow">
         <div class="col-sm-5 col-sm-offset-1 col-xs-12">
           <img class="centered" src="{{ site.baseurl }}/images/Icon-Press.png" />
           <h2 class="centered">Press Inquiries</h2>
           <p>Are you a member of the media wishing to speak with one of our team members?</p>
+          <a class="spaced btn btn-primary btn-lg" href="{{ site.baseurl }}/press/">
+            REACH OUT
+          </a>
         </div>
         <div class="col-sm-5 col-xs-12">
           <img class="centered" src="{{ site.baseurl }}/images/Icon-Twitter.png" />
           <h2 class="centered">Twitter</h2>
           <p>Follow us <a href="https://twitter.com/DullesJustice">@DullesJustice</a> or the hashtag
           <a href="https://twitter.com/hashtag/DullesJustice">#DullesJustice</a> for the latest information. </p>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-5 col-sm-offset-1 col-xs-12">
-          <a class="spaced btn btn-primary btn-lg" href="{{ site.baseurl }}/press/">
-            REACH OUT
-          </a>
-        </div>
-        <div class="col-sm-5 col-xs-12">
           <a class="spaced btn btn-primary btn-lg" href="https://twitter.com/DullesJustice">
             TWITTER
           </a>
         </div>
-
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -52,42 +52,30 @@ permalink: /
   <div class="row padbottom50">
     <div class="col-sm-offset-1 col-sm-10 col-xs-12">
       <div class="row">
-        <div class="col-sm-4 col-xs-12">
+        <div class="col-sm-5 col-sm-offset-1 col-xs-12">
           <img class="centered" src="{{ site.baseurl }}/images/Icon-Press.png" />
           <h2 class="centered">Press Inquiries</h2>
           <p>Are you a member of the media wishing to speak with one of our team members?</p>
         </div>
-        <div class="col-sm-4 col-xs-12">
+        <div class="col-sm-5 col-xs-12">
           <img class="centered" src="{{ site.baseurl }}/images/Icon-Twitter.png" />
           <h2 class="centered">Twitter</h2>
           <p>Follow us <a href="https://twitter.com/DullesJustice">@DullesJustice</a> or the hashtag
           <a href="https://twitter.com/hashtag/DullesJustice">#DullesJustice</a> for the latest information. </p>
         </div>
-       <div class="col-sm-4 col-xs-12">
-          <img class="centered" src="{{ site.baseurl }}/images/Icon-Insta.png" />
-          <h2 class="centered">Instagram</h2>
-          <p>See Dulles Justice from the eyes of volunteers and affected people at
-            <a href="https://www.instagram.com/dullesjustice/">@DullesJustice</a> on Instagram.</p>
-        </div>
-      
       </div>
       <div class="row">
-        <div class="col-sm-4 col-xs-12">
+        <div class="col-sm-5 col-sm-offset-1 col-xs-12">
           <a class="spaced btn btn-primary btn-lg" href="{{ site.baseurl }}/press/">
             REACH OUT
           </a>
         </div>
-        <div class="col-sm-4 col-xs-12">
+        <div class="col-sm-5 col-xs-12">
           <a class="spaced btn btn-primary btn-lg" href="https://twitter.com/DullesJustice">
             TWITTER
           </a>
         </div>
-        <div class="col-sm-4 col-xs-12">
-          <a class="spaced btn btn-primary btn-lg" href="https://www.instagram.com/dullesjustice/">
-            INSTAGRAM
-          </a>
-        </div>
-     
+
       </div>
     </div>
   </div>


### PR DESCRIPTION
Hey y'all -- I forget what the release process is on these -- merge into the appropriate branches as necessary

- Removes the links to instagram as requested by @edyskant 
- Minor styling tweak so both row styles are doing the same thing (puts buttons in a sensible place on mobile)